### PR TITLE
Fixed function arguments

### DIFF
--- a/src/logic/postman.js
+++ b/src/logic/postman.js
@@ -87,7 +87,7 @@ class Postman {
         }
         if (Array.isArray(items)) {
             for (const item of items) {
-                this._updateCollection(mapping.item);
+                this._updateCollection(mapping, item);
             }
         } else {
             this._updateCollection(mapping, items);


### PR DESCRIPTION
The `_updateCollection` function expects two arguments but it was getting passed a single, undefined variable which was causing the program to fail.

**Before code fix:**

```
npx @syngenta-digital/pdt --collection-file postman/api.postman_collection.json --doc-path swagger.yml
===== POSTMAN DOCUMENTATION TESTER STARTED =====
--VALIDATING ARGUMENTS
--READING COLLECTION FILE
--VALIDATING POSTMAN COLLECTIONS & ENVIRONMENTS
--READING SCHEMA FILE
--MAPPING COLLECTION TO SCHEMA
/path/to/repo/node_modules/@syngenta-digital/pdt/src/logic/postman.js:105
        if (item.request && item.request.hasOwnProperty('url')) {
                 ^

TypeError: Cannot read properties of undefined (reading 'request')
```


**After code fix:**

```
npx @syngenta-digital/pdt --collection-file postman/api.postman_collection.json --doc-path swagger.yml
===== POSTMAN DOCUMENTATION TESTER STARTED =====
--VALIDATING ARGUMENTS
--READING COLLECTION FILE
--VALIDATING POSTMAN COLLECTIONS & ENVIRONMENTS
--READING SCHEMA FILE
--MAPPING COLLECTION TO SCHEMA
--SAVING UPDATED COLLECTION
===== POSTMAN DOCUMENTATION TESTER COMPLETED =====
```